### PR TITLE
Update users of the mechanical repositories

### DIFF
--- a/groups/mws-iit.yml
+++ b/groups/mws-iit.yml
@@ -1,0 +1,4 @@
+mws-iit/mech:
+  - "miggia"
+  - "divyashah"
+  - "mpinaffo"

--- a/repos/cad-libraries.yml
+++ b/repos/cad-libraries.yml
@@ -1,0 +1,8 @@
+cad-libraries:
+  dic-iit/mech:
+    type: "group"
+    permission: "read"
+
+  mws-iit/mech:
+    type: "group"
+    permission: "read"

--- a/repos/cad-mechanics.yml
+++ b/repos/cad-mechanics.yml
@@ -7,14 +7,6 @@ cad-mechanics:
     type: "user"
     permission: "write"
 
-  miggia:
-    type: "user"
-    permission: "read"
-  
-  mpinaffo:
-    type: "user"
-    permission: "read"
-  
-  divyashah:
-    type: "user"
+  mws-iit/mech:
+    type: "group"
     permission: "read"

--- a/repos/mechatronics.yml
+++ b/repos/mechatronics.yml
@@ -1,0 +1,4 @@
+mechatronics:
+  dic-iit/mech:
+    type: "group"
+    permission: "read"


### PR DESCRIPTION
This PR includes the following modifications to groups and users:
- created a MWS group
- updated the `cad-mechanics` users list to use the new MWS group
- created the files for the outside collaborators of the `cad-libraries` and `mechatronics` repositories