### PR TITLE
Add user to icub-snapshot

### DIFF
--- a/repos/icub-snapshots.yml
+++ b/repos/icub-snapshots.yml
@@ -1,0 +1,4 @@
+icub-snapshots:
+  iiborisov:
+    type: "user"
+    permission: "read"


### PR DESCRIPTION
As per title added the GitHub username of an iCub customer that needs access to the CAD model of his robot.