### PR TITLE
Delete cad-libraries.yml

### DIFF
--- a/repos/cad-libraries.yml
+++ b/repos/cad-libraries.yml
@@ -1,8 +1,0 @@
-cad-libraries:
-  dic-iit/mech:
-    type: "group"
-    permission: "read"
-
-  mws-iit/mech:
-    type: "group"
-    permission: "read"


### PR DESCRIPTION
As per title, deleting the `cad-libraries` file because the repository is now public.