### PR TITLE
Add PI's to teams repos

### DIFF
--- a/repos/teams-repos.yml
+++ b/repos/teams-repos.yml
@@ -1,0 +1,43 @@
+fix:
+  lornat75:
+    type: "user"
+    permissions: "read"
+  DanielePucci:
+    type: "user"
+    permissions: "read"
+  ChiaraBartolozzi:
+    type: "user"
+    permissions: "read"
+
+code:
+  lornat75:
+    type: "user"
+    permissions: "read"
+  DanielePucci:
+    type: "user"
+    permissions: "read"
+  ChiaraBartolozzi:
+    type: "user"
+    permissions: "read"
+
+dev:
+  lornat75:
+    type: "user"
+    permissions: "read"
+  DanielePucci:
+    type: "user"
+    permissions: "read"
+  ChiaraBartolozzi:
+    type: "user"
+    permissions: "read"
+
+proto:
+  lornat75:
+    type: "user"
+    permissions: "read"
+  DanielePucci:
+    type: "user"
+    permissions: "read"
+  ChiaraBartolozzi:
+    type: "user"
+    permissions: "read"


### PR DESCRIPTION
This PR adds up @lornat75 @DanielePucci and @ChiaraBartolozzi to our teams repos (i.e. where we've been running Agile) with `read` permissions.

cc @icub-tech-iit/board