### PR TITLE
added electronics-legacy

### DIFF
--- a/repos/electronics-legacy.yml
+++ b/repos/electronics-legacy.yml
@@ -1,0 +1,12 @@
+electronics-legacy:
+  dic-iit/electronics:
+    type: "group"
+    permissions: "read"
+
+  edpr-iit/electronics:
+    type: "group"
+    permissions: "read"
+
+  hsp-iit/electronics:
+    type: "group"
+    permissions: "read"


### PR DESCRIPTION
`electronics-legacy` is the old electronics repository containing many information and projects that were not moved to the `electronics-boards` repository, which is mainly the container of electronic boards and projects more related to the robots.
For this reason `electronics-legacy` shouldn't be removed, it is the archive of our work.

With this PR I would like to add in read mode to this repository external collaborators that need to find useful information on old projects. In particular, people of the following organization:
- dic-iit/electronics
- edpr-iit/electronics
- hsp-iit/electronics: