### PR TITLE
Delete invitations

### DIFF
--- a/.github/workflows/delete-invitations.yml
+++ b/.github/workflows/delete-invitations.yml
@@ -1,0 +1,34 @@
+name: Delete Invitations
+
+on:
+  workflow_dispatch:
+    inputs:
+      repositories:
+        description: 'A comma-separated list of repos containing the invitations to delete'
+        required: true
+        default: '*'
+
+concurrency:
+  group: outside_collaborators_delete_invitations
+  cancel-in-progress: true
+
+jobs:
+  Check:
+    name: "Delete"
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Install Dependencies
+        run: |
+          sudo gem install octokit yaml
+      - name: Set Env Variables
+        run: |
+          echo "OUTSIDE_COLLABORATORS_GITHUB_ORG=${{ github.repository_owner }}" >> ${GITHUB_ENV}
+          echo "OUTSIDE_COLLABORATORS_GITHUB_TOKEN=${{ secrets.OUTSIDE_COLLABORATORS_TOKEN }}" >> ${GITHUB_ENV}
+          echo "OUTSIDE_COLLABORATORS_REPOS_DELETE_INVITATIONS=\"${{ github.event.inputs.repositories }}\"" >> ${GITHUB_ENV}
+      - uses: actions/checkout@main
+      - name: Run Handler
+        run: |
+          cd scripts
+          ./delete-invitations.rb
+      

--- a/README.md
+++ b/README.md
@@ -152,6 +152,16 @@ semantically correct that the automation does no longer handle it.
 
 Obviously, one can also perform a manual cleanup straight away.
 
+### Cleaning up stale invitations
+[Pending invitations self-expire after a few days](https://docs.github.com/en/organizations/managing-membership-in-your-organization/inviting-users-to-join-your-organization).
+
+It may happen that certain invitees do not want to join the intended repositories as external
+collaborators. In this regard, we do not clean up automatically stale invitations to use them as
+indicators that we shall not spam those invitees with continuous requests at every automation run.
+
+However, it might be convenient sometimes to clean up stale invitations on demand. To this end,
+one can rely on the manually-triggered workflow [`Delete Invitations`](./.github/workflows/delete-invitations.yml).
+
 ## ⚙ Automation for your organization
 Follow the quick guide below if you want to install this automation in your organization:
 1. [Create a copy](../../generate) of this dashboard repository in your organization account.

--- a/scripts/delete-invitations.rb
+++ b/scripts/delete-invitations.rb
@@ -1,0 +1,70 @@
+#!/usr/bin/env ruby
+
+# Copyright: (C) 2020 iCub Tech Facility - Istituto Italiano di Tecnologia
+# Authors: Ugo Pattacini <ugo.pattacini@iit.it>
+
+
+#########################################################################################
+# deps
+require 'octokit'
+require 'yaml'
+require './helpers'
+
+
+#########################################################################################
+# global vars
+$org = ENV['OUTSIDE_COLLABORATORS_GITHUB_ORG']
+$client = Octokit::Client.new :access_token => ENV['OUTSIDE_COLLABORATORS_GITHUB_TOKEN']
+
+
+#########################################################################################
+# traps
+Signal.trap("INT") {
+  exit 2
+}
+
+Signal.trap("TERM") {
+  exit 2
+}
+
+
+#########################################################################################
+# main
+
+# retrieve information from files
+groups = get_entries("../groups")
+repos = get_entries("../repos")
+
+# retrieve input repos 
+repos_input = ENV['OUTSIDE_COLLABORATORS_REPOS_DELETE_INVITATIONS'].split(/\s*,\s*/)
+puts "📃 List of automated repositories to process: #{repos_input}"
+
+# cycle over repos
+repos.each { |repo_name, repo_metadata|
+    repo_full_name = $org + "/" + repo_name
+    puts "Processing automated repository \"#{repo_full_name}\"..."
+
+    check_and_wait_until_reset
+    if $client.repository?(repo_full_name) then
+        # check if we're required to deal with this repo
+        if repos_input.include?('*') || repos_input.include?(repo_name) then
+            # delete invitations
+            get_repo_invitations(repo_full_name).each { |invitation|
+                invitee = invitation["invitee"]
+                check_and_wait_until_reset
+                if !$client.org_member?($org, invitee) then
+                    puts "- Removing invitee \"#{invitee}\""
+                    check_and_wait_until_reset
+                    $client.delete_repository_invitation(repo_full_name, invitation["id"])
+                end
+            }
+
+            puts "...done with \"#{repo_full_name}\" ✔"
+        else
+            puts "Repository \"#{repo_full_name}\" is not in the list ➖"
+        end
+    else
+        puts "Repository \"#{repo_full_name}\" does not exist ❌"
+    end
+    puts ""
+}


### PR DESCRIPTION
This PR addresses #68 in a way that is slightly different as requested.

The new manually-triggered workflow is called `Delete invitations` and only pertains to the possibility to remove pending/stale invitations from within the specified repositories, keeping the main functionality of updating/inviting collaborators under the responsibility of the core workflow.

The repositories to clean up are specified by means of a comma-separated list.

Other points:
- README has been updated accordingly.
- some helper functions have been moved to `helper.rb`.