### PR TITLE
Expired invitations cause problems

### DIFF
--- a/scripts/helpers.rb
+++ b/scripts/helpers.rb
@@ -52,9 +52,13 @@ def get_repo_invitations(repo)
     last_response = $client.last_response
     loop do
         data = last_response.data
-        data.each { |i| invitations << {"id" => i.id,
-                                        "invitee" => i.invitee.login,
-                                        "permissions" => i.permissions} }
+        data.each { |i| 
+            if !i.expired then
+                invitations << {"id" => i.id,
+                                "invitee" => i.invitee.login,
+                                "permissions" => i.permissions}
+            end
+        }
         if last_response.rels[:next].nil?
             break
         else

--- a/tests/test_helpers.rb
+++ b/tests/test_helpers.rb
@@ -1,0 +1,57 @@
+require_relative '../scripts/helpers'
+require 'minitest/autorun'
+ 
+$client = Minitest::Mock.new
+def $client.rate_limit
+    rate_limit = Minitest::Mock.new
+    def rate_limit.remaining; return 100; end
+    return rate_limit
+end
+
+def $client.repository_invitations(repo); return true; end
+
+$response = Minitest::Mock.new
+def $client.last_response
+  def $response.rels; return {:next => nil}; end
+  return $response
+end
+
+class TestHelpers < Minitest::Test
+  def test_empty_get_repo_invitations
+    $response.expect :data, []
+    assert_equal(0, get_repo_invitations(Minitest::Mock.new).length)
+  end
+  
+  def test_single_get_repo_invitations
+    invite = Minitest::Mock.new
+    def invite.expired; return false; end
+    def invite.id; return nil; end
+    def invite.permissions; return nil; end 
+    def invite.invitee
+      invitee = Minitest::Mock.new
+      def invitee.login; return nil; end
+      return invitee
+    end
+
+    $response.expect :data, [invite]
+    assert_equal(1, get_repo_invitations(Minitest::Mock.new).length)
+  end
+  
+  def test_single_with_expired_get_repo_invitations
+    invite = Minitest::Mock.new
+    def invite.expired; return false; end
+    def invite.id; return nil; end
+    def invite.permissions; return nil; end 
+    def invite.invitee
+      invitee = Minitest::Mock.new
+      def invitee.login; return nil; end
+      return invitee
+    end
+
+    invite2 = Minitest::Mock.new
+    def invite2.expired; return true; end
+
+    $response.expect :data, [invite, invite2]
+    assert_equal(1, get_repo_invitations(Minitest::Mock.new).length)
+  end
+end


### PR DESCRIPTION
Hi, 

I had the following error in my "Update Outside Collaborators" action

```
	from ./outside-collaborators-handler.rb:168:in `block (3 levels) in <main>'
	from ./outside-collaborators-handler.rb:165:in `each'
	from ./outside-collaborators-handler.rb:165:in `block (2 levels) in <main>'
	from ./outside-collaborators-handler.rb:155:in `each'
	from ./outside-collaborators-handler.rb:155:in `block in <main>'
	from ./outside-collaborators-handler.rb:147:in `each'
	from ./outside-collaborators-handler.rb:147:in `<main>'
```

After a little debugging, I found out, that I have a failed invitation in my repo.

<img width="1293" alt="Screenshot 2022-03-29 at 09 02 43" src="https://user-images.githubusercontent.com/588110/160661978-990de787-047b-4877-99ef-c524cc09c1bb.png">

I found out, that there is an addtional field ":expired=>true" in the response of helpers.rb#44 ($client.repository_invitations). In https://docs.github.com/en/rest/reference/collaborators#invitations it isn't documented for the list action, but for the update action. Nevertheless its there in both cases for my repo.

So I made a little fix and added a test for it. 