### PR TITLE
Possibility to delete expired invitations only

### DIFF
--- a/.github/workflows/delete-invitations.yml
+++ b/.github/workflows/delete-invitations.yml
@@ -7,6 +7,11 @@ on:
         description: 'A comma-separated list of repos containing the invitations to delete (use the wildcard * for all)'
         required: true
         default: '*'
+      only_expired:
+        type: boolean
+        description: 'Delete expired invitations only'
+        required: true
+        default: true
 
 concurrency:
   group: outside_collaborators_delete_invitations
@@ -26,6 +31,7 @@ jobs:
           echo "OUTSIDE_COLLABORATORS_GITHUB_ORG=${{ github.repository_owner }}" >> ${GITHUB_ENV}
           echo "OUTSIDE_COLLABORATORS_GITHUB_TOKEN=${{ secrets.OUTSIDE_COLLABORATORS_TOKEN }}" >> ${GITHUB_ENV}
           echo "OUTSIDE_COLLABORATORS_REPOS_DELETE_INVITATIONS=${{ github.event.inputs.repositories }}" >> ${GITHUB_ENV}
+          echo "OUTSIDE_COLLABORATORS_ONLY_EXPIRED_INVITATIONS=${{ github.event.inputs.only_expired }}" >> ${GITHUB_ENV}
       - uses: actions/checkout@main
       - name: Run Handler
         run: |

--- a/scripts/helpers.rb
+++ b/scripts/helpers.rb
@@ -54,7 +54,8 @@ def get_repo_invitations(repo)
         data = last_response.data
         data.each { |i| invitations << {"id" => i.id,
                                         "invitee" => i.invitee.login,
-                                        "permissions" => i.permissions} }
+                                        "permissions" => i.permissions,
+                                        "expired" => i.expired} }
         if last_response.rels[:next].nil?
             break
         else


### PR DESCRIPTION
Following up on #129 and while chatting with @nachtgold, I've learned that I can exploit the somewhat undocumented field `expired` of the returned hash of the `repository_invitations` query to narrow down the deletion to expired invitations only.