### PR TITLE
Changed the escape char for group mentioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,13 +118,11 @@ Pay attention to the following points:
 
 ### Mentioning a group
 Anyone posting a message in an issue or a PR of a org repository where the outside collaborators automation is
-established can mention a group using the following _bash-like_ convention:
-- `$group-name`
-- `${group-name}`
+established can mention a group using the convention `!group-name`.
 
 For example, if `user01` posts:
 ```markdown
-Hey ${lab_xyz/group01} 👋🏻
+Hey !lab_xyz/group01 👋🏻
 I've got an exciting news to share with you!
 ```
 

--- a/scripts/mentioning-comment-handler.rb
+++ b/scripts/mentioning-comment-handler.rb
@@ -85,12 +85,10 @@ author = info.user.login
 collaborators = ""
 repo_metadata.each { |user, props|
     if (props["type"].casecmp?("group")) then
-        tag_1 = "$" + user
-        tag_2 = "${" + user + "}"
-        if (body.include? tag_1) || (body.include? tag_2) then
+        tag = "!" + user
+        if body.include? tag then
             # avoid self-notifying
-            body = body.gsub(tag_1, user)
-            body = body.gsub(tag_2, user)
+            body = body.gsub(tag, user)
             if groups.key?(user) then
                 puts "- Handling of notified group \"#{user}\" 👥"
                 groups[user].each { |subuser|


### PR DESCRIPTION
As of today, GitHub has introduced [MathJax support][mathjax] for rendering mathematical expressions in markdown. MathJax relies on the use of `$` escape char, which of course interferes with our group mentioning mechanism.

Therefore, this PR replaces the use of `$` with `!` as the new escape char.

[mathjax]: https://github.blog/changelog/2022-05-19-render-mathematical-expressions-in-markdown