### PR TITLE
Add singhbal-baljinder to ami-iit/mech

### DIFF
--- a/groups/ami-iit.yml
+++ b/groups/ami-iit.yml
@@ -70,6 +70,7 @@ ami-iit/mech:
   - "Gianmarcogatti93"
   - "claudia-lat"
   - "antonellopaolino"
+  - "singhbal-baljinder"
   
 ami-iit/sw-dev:
   - "DanielePucci"


### PR DESCRIPTION
The main reason is to give access to @singhbal-baljinder to the documentation in https://github.com/icub-tech-iit/cad-mechanics/wiki/Install-and-configure-PTC-Creo-Parametric .