### PR TITLE
Re-add affafj to ami-iit.yml

### DIFF
--- a/groups/ami-iit.yml
+++ b/groups/ami-iit.yml
@@ -42,6 +42,7 @@ ami-iit/everyone:
   - "pillai-s"
   - "marcoforleo"
   - "akhilsathuluri"
+  - "affafj"
   
 ami-iit/purchases:
   - "DanielePucci"
@@ -125,6 +126,7 @@ ami-iit/sw-dev:
   - "pillai-s"
   - "marcoforleo"
   - "akhilsathuluri"
+  - "affafj"
 
 ami-iit/electronics:
   - "DanielePucci"


### PR DESCRIPTION
It was removed in https://github.com/icub-tech-iit/outside-collaborators/pull/180#issuecomment-1602258877 after its username changed affafjunaidMOMIN from affafj .

fyi @affafj @DanielePucci @GabrieleNava