### PR TITLE
ami-iit: Add xela-95 to ami-iit/mech

### DIFF
--- a/groups/ami-iit.yml
+++ b/groups/ami-iit.yml
@@ -88,6 +88,7 @@ ami-iit/mech:
   - "pillai-s"
   - "nicktrem"
   - "lorycontixd"
+  - "xela-95"
   
 ami-iit/sw-dev:
   - "DanielePucci"


### PR DESCRIPTION
@xela-95 works on gz-sim integration and URDF generation, so he needs access to the ergocub cad models to generate the ergocub URDFs. 

fyi @DanielePucci 