### PR TITLE
Add creo2urdf-private repo to outside-collaborators

### DIFF
--- a/repos/creo2urdf-private.yaml
+++ b/repos/creo2urdf-private.yaml
@@ -1,0 +1,16 @@
+creo2urdf-private:
+  ami-iit/mech:
+    type: "group"
+    permissions: "read"
+
+  ami-iit/sw-dev:
+    type: "group"
+    permissions: "read"
+
+  hsp-iit/sw-dev:
+    type: "group"
+    permissions: "read"
+
+  edpr-iit/sw-dev:
+    type: "group"
+    permissions: "read"


### PR DESCRIPTION
As the `creo2urdf-private` can be interesting for both mechanical and software people, I added both mech and sw-dev groups from the research lines.