### PR TITLE
Fix YAML files concatenation

### DIFF
--- a/scripts/helpers.rb
+++ b/scripts/helpers.rb
@@ -21,7 +21,7 @@ end
 #########################################################################################
 def get_entries(dirname)
     files = Dir[dirname + "/*.yml"]
-    files << Dir[dirname + "/*.yaml"]
+    files = files + Dir[dirname + "/*.yaml"]
 
     entries = {}
     if files then


### PR DESCRIPTION
This PR fixes the problem spotted in #220, whose [CI failed](https://github.com/icub-tech-iit/outside-collaborators/actions/runs/9001700068) because the two variables were appended rather than concatenated.

cc @traversaro  