### PR TITLE
Fix for Pysch 4 load_file

### DIFF
--- a/scripts/helpers.rb
+++ b/scripts/helpers.rb
@@ -27,7 +27,12 @@ def get_entries(dirname)
     if files then
         files.each { |file|
             if !file.empty? then
-                entries.merge!(YAML.load_file(file, aliases: true))
+                begin
+                  doc = YAML.load_file(file, aliases: true)
+                rescue ArgumentError
+                  doc = YAML.load_file(file)
+                end
+                entries.merge!(doc)
             end
         }
     end


### PR DESCRIPTION
This PR tries to address the breaking change introduced by the update from Pysch 3 to Pysch 4 about YAML load_file.

See https://stackoverflow.com/a/71192990/3956237.
