### PR TITLE
Use GH Codespaces in lieu of Gitpod

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -17,8 +17,8 @@ RUN apt install -y apt-utils software-properties-common apt-transport-https sudo
 # Install gems
 RUN gem install octokit yaml
 
-# Create user gitpod
-RUN useradd -l -u 33333 -G sudo -md /home/gitpod -s /bin/bash -p gitpod gitpod && \
+# Create user codespace
+RUN useradd -l -u 33333 -G sudo -md /home/codespace -s /bin/bash -p codespace codespace && \
     # passwordless sudo for users in the 'sudo' group
     sed -i.bkp -e 's/%sudo\s\+ALL=(ALL\(:ALL\)\?)\s\+ALL/%sudo ALL=NOPASSWD:ALL/g' /etc/sudoers
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,11 @@
+{
+	"name": "CDE for Outside Collaborators",
+	"build": {
+		"dockerfile": "Dockerfile"
+	},
+	"forwardPorts": [ ],
+	"remoteUser": "codespace",
+	"remoteEnv": {
+		"OUTSIDE_COLLABORATORS_GITHUB_ORG": "icub-tech-iit"
+	}
+}

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,7 +1,0 @@
-image:
-  file: .gitpod.Dockerfile
-tasks:
-- before: |
-    echo "export OUTSIDE_COLLABORATORS_GITHUB_ORG=icub-tech-iit" >> ~/.bashrc-custom
-    echo "source ~/.bashrc-custom" >> ~/.bashrc
-    source ~/.bashrc-custom


### PR DESCRIPTION
This PR replaces Gitpod as CDE with GH Codespaces (when/if available on org or user basis).