### PR TITLE
Add Giulero and HosameldinMohamed to ami-iit/mech

### DIFF
--- a/groups/ami-iit.yml
+++ b/groups/ami-iit.yml
@@ -89,6 +89,8 @@ ami-iit/mech:
   - "GiulioRomualdi"
   - "mebbaid"
   - "Supermonkey-design"
+  - "Giulero"
+  - "HosameldinMohamed"
 
 ami-iit/sw-dev:
   - "DanielePucci"


### PR DESCRIPTION
While @Giulero and @HosameldinMohamed are not directly mechanical engineers, they coordinate a team in which substantial mechanical engineering work is done, so it would be useful for them to have access to `icub-tech-iit/cad-mechanics`.